### PR TITLE
handle formData errors, separate from body

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ function validate(args) {
   var bodySchema = schemas.body;
   var bodyValidationSchema;
   var headersSchema = lowercasedHeaders(schemas.headers);
+  var formDataSchema = schemas.formData;
   var pathSchema = schemas.path;
   var querySchema = schemas.query;
   var v = new JsonschemaValidator();
@@ -102,6 +103,11 @@ function validate(args) {
           schema: bodySchema
         };
       }
+    }
+
+    if (req.params && formDataSchema) {
+      errors.push.apply(errors, withAddedLocation('formData', v.validate(
+          req.params, formDataSchema).errors));
     }
 
     if (req.params && pathSchema) {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   },
   "dependencies": {
     "jsonschema": "^1.1.0",
-    "openapi-jsonschema-parameters": "^0.1.3"
+    "openapi-jsonschema-parameters": "^0.2.0"
   }
 }

--- a/test/data-driven/fail-a-missing-required-formData-property.js
+++ b/test/data-driven/fail-a-missing-required-formData-property.js
@@ -24,16 +24,10 @@ module.exports = {
     status: 400,
     errors: [
       {
-        location: 'body',
-        message: 'req.body was not present in the request.  Is a body-parser being used?',
-        schema: {
-          properties: {
-            foo: {
-              type: 'string'
-            }
-          },
-          required: ['foo']
-        }
+        path: 'foo',
+        errorCode: 'required.openapi.validation',
+        message: 'instance requires property "foo"',
+        location: 'formData'
       }
     ]
   })


### PR DESCRIPTION
Hi!

I've just posted a PR on https://github.com/kogosoftwarellc/openapi-jsonschema-parameters/pull/1.
So I'm modifying this lib too because they were breaking changes, and also to be able to handle formData errors apart from body errors in openApi validation.

using version ^0.2.0 in package.json, assuming that the next version of openapi-jsonschema-parameters will be 0.2.0.

Thank you!