### PR TITLE
Add toString() method to err object

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,10 +136,11 @@ function validate(args) {
         errors: [schemaError]
       };
     }
-
-    err.toString = function() {
-      return JSON.stringify(this.errors);
-    };
+    if (err) {
+      err.toString = function() {
+        return JSON.stringify(this.errors);
+      };
+    }
 
     next(err);
   };

--- a/index.js
+++ b/index.js
@@ -137,6 +137,10 @@ function validate(args) {
       };
     }
 
+    err.toString = function() {
+      return JSON.stringify(this.errors);
+    };
+
     next(err);
   };
 }


### PR DESCRIPTION
Node calls toString() on error objects that have the method defined. Previously, if a request did not pass validation, the response body was `[object Object]`. Now the toString() method will be called, which stringifies and returns err.errors (an array of validation errors). This stringified JSON will now be the body of the response.